### PR TITLE
Minor fixes

### DIFF
--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -13,25 +13,28 @@ fn main() {
     server.POST("/container/:id/reboot", |r: &Request| Response {
         response_code: 200,
         headers: None,
-        body: Some(BodyType::Plain(
-            format!("Container ID is: {}\nRebooting...\nTEST", r.rest_params.get("id").unwrap())
-        )),
+        body: Some(BodyType::Plain(format!(
+            "Container ID is: {}\nRebooting...\nTEST",
+            r.rest_params.get("id").unwrap()
+        ))),
     });
 
     server.POST("/container/:id/start", |r: &Request| Response {
         response_code: 200,
         headers: None,
-        body: Some(BodyType::Plain(
-            format!("Container ID is: {}\nStarting...\nTEST", r.rest_params.get("id").unwrap())
-        )),
+        body: Some(BodyType::Plain(format!(
+            "Container ID is: {}\nStarting...\nTEST",
+            r.rest_params.get("id").unwrap()
+        ))),
     });
 
     server.POST("/container/:id/stop", |r: &Request| Response {
         response_code: 200,
         headers: None,
-        body: Some(BodyType::Plain(
-            format!("Container ID is: {}\nStopping...\nTEST", r.rest_params.get("id").unwrap())
-        )),
+        body: Some(BodyType::Plain(format!(
+            "Container ID is: {}\nStopping...\nTEST",
+            r.rest_params.get("id").unwrap()
+        ))),
     });
 
     server.start();

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,33 +1,37 @@
 // Файл, который лежит в src/bin/*.rs образует crate-исполняемый файл (main)
 // Из main можно пользоваться только тем, что выставлено наружу (pub) из библиотечного crate и корректно объявлено в lib.rs
 use backend::lib::handlers::handler_return_all_containers;
-use backend::lib::req_res_structs::Response;
-use backend::lib::request::Request;
 use backend::lib::http_server::Server;
+use backend::lib::req_res_structs::{BodyType, Response};
+use backend::lib::request::Request;
 fn main() {
     let mut server = Server::new("127.0.0.1:8080").unwrap();
 
     // регистрация пары path и handlers в Hash-table
     server.GET("/container/", handler_return_all_containers); // 2ой аргумент это тип HandlerFn
 
-    server.POST("/container/:id/reboot", |r: &Request| {
-        Response {
-            response_code: 200,
-            headers: None,
-            body: None,
-        }
+    server.POST("/container/:id/reboot", |r: &Request| Response {
+        response_code: 200,
+        headers: None,
+        body: Some(BodyType::Plain(
+            format!("Container ID is: {}\nRebooting...\nTEST", r.rest_params.get("id").unwrap())
+        )),
     });
 
     server.POST("/container/:id/start", |r: &Request| Response {
         response_code: 200,
         headers: None,
-        body: None,
+        body: Some(BodyType::Plain(
+            format!("Container ID is: {}\nStarting...\nTEST", r.rest_params.get("id").unwrap())
+        )),
     });
 
     server.POST("/container/:id/stop", |r: &Request| Response {
         response_code: 200,
         headers: None,
-        body: None,
+        body: Some(BodyType::Plain(
+            format!("Container ID is: {}\nStopping...\nTEST", r.rest_params.get("id").unwrap())
+        )),
     });
 
     server.start();

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -1,16 +1,16 @@
 // Файл, который лежит в src/bin/*.rs образует crate-исполняемый файл (main)
 // Из main можно пользоваться только тем, что выставлено наружу (pub) из библиотечного crate и корректно объявлено в lib.rs
 use backend::lib::handlers::handler_return_all_containers;
-use backend::lib::req_res_structs::{BodyType, Response};
+use backend::lib::req_res_structs::Response;
 use backend::lib::request::Request;
-use backend::lib::{http_server::Server, parse_funcs::deser_response};
+use backend::lib::http_server::Server;
 fn main() {
     let mut server = Server::new("127.0.0.1:8080").unwrap();
 
     // регистрация пары path и handlers в Hash-table
-    server.GET("/container/".to_string(), handler_return_all_containers); // 2ой аргумент это тип HandlerFn
+    server.GET("/container/", handler_return_all_containers); // 2ой аргумент это тип HandlerFn
 
-    server.POST("/container/:id/reboot".to_string(), |r: &Request| {
+    server.POST("/container/:id/reboot", |r: &Request| {
         Response {
             response_code: 200,
             headers: None,
@@ -18,13 +18,13 @@ fn main() {
         }
     });
 
-    server.POST("/container/:id/start".to_string(), |r: &Request| Response {
+    server.POST("/container/:id/start", |r: &Request| Response {
         response_code: 200,
         headers: None,
         body: None,
     });
 
-    server.POST("/container/:id/stop".to_string(), |r: &Request| Response {
+    server.POST("/container/:id/stop", |r: &Request| Response {
         response_code: 200,
         headers: None,
         body: None,

--- a/src/lib/docker_works.rs
+++ b/src/lib/docker_works.rs
@@ -38,7 +38,7 @@ impl std::fmt::Display for ContainerStatus {
             ContainerStatus::Dead => "Dead",
         };
         // макрос write! записывает в форматер f строку s
-        write!(f, "{}", stroka)
+        write!(f, "{stroka}")
     }
 }
 

--- a/src/lib/handlers.rs
+++ b/src/lib/handlers.rs
@@ -3,7 +3,7 @@ use crate::lib::req_res_structs::{BodyType, Response}; // стрктура от�
 use crate::lib::request::Request; // структура запроса
 use serde_json;
 
-pub fn handler_return_all_containers(request: &Request) -> Response {
+pub fn handler_return_all_containers(_request: &Request) -> Response {
     // Нужно обработать request и вернуть Response
     // Данный handler должен возвращать весь вектор ContainerInfo
 
@@ -72,7 +72,7 @@ pub fn handler_return_all_containers(request: &Request) -> Response {
 
             resp
         }
-        Err(error) => {
+        Err(_) => {
             let resp: Response = Response {
                 // мой возвращаемый Response
                 response_code: 500,

--- a/src/lib/handlers.rs
+++ b/src/lib/handlers.rs
@@ -37,7 +37,6 @@ pub fn handler_return_all_containers(_request: &Request) -> Response {
                 });
                 // вставляем пару: ключ - one_container.label и значение - description_for_label
                 map.insert(one_container.label, description_for_label);
-                println!("{:?}", map);
                 /*  Теперь в map хранится следующее:
                 "analytics": {
                     "command": "/opt/spark/bin/spark-class org.apache.spark.deploy.worker.Worker ...",

--- a/src/lib/http_server.rs
+++ b/src/lib/http_server.rs
@@ -340,8 +340,7 @@ impl Server {
                         let mut found_path = false;
 
                         for (key, value) in self.handlers.get(&request.method).unwrap() {
-                            if request.is_exact(key) {
-                                
+                            if request.is_similar(key) {
                                 request.parse_args(key);
 
                                 let response = value(&request);

--- a/src/lib/http_server.rs
+++ b/src/lib/http_server.rs
@@ -17,7 +17,7 @@ type HandlerFn = fn(&Request) -> Response;
 #[derive(Debug)]
 pub struct Server {
     listener: TcpListener,
-    handlers: HashMap<Method, HashMap<String, HandlerFn>>,
+    handlers: HashMap<Method, HashMap<&'static str, HandlerFn>>,
 }
 
 /*
@@ -63,7 +63,7 @@ impl Server {
             .map_err(|e| ServerError::InitError(format!("Failed to init TCP listener: {e}")))?;
 
         // Инициализируем нашу Hash-map таблицу, которая будет хранить handlers для различных путей
-        let mut handlers: HashMap<Method, HashMap<String, HandlerFn>> = HashMap::new();
+        let mut handlers: HashMap<Method, HashMap<&str, HandlerFn>> = HashMap::new();
 
         handlers.insert(Method::GET, HashMap::new());
         handlers.insert(Method::POST, HashMap::new());
@@ -78,10 +78,10 @@ impl Server {
     pub fn add_handler(
         &mut self,
         method: Method,
-        path: String,
+        path: &'static str,
         handler: HandlerFn,
     ) -> Result<(), ServerError> {
-        let paths: &mut HashMap<String, HandlerFn> = self.handlers.get_mut(&method).unwrap(); // Получаем Hash-map таблицу с путями и handlers
+        let paths: &mut HashMap<&str, HandlerFn> = self.handlers.get_mut(&method).unwrap(); // Получаем Hash-map таблицу с путями и handlers
         if paths.contains_key(&path) {
             // в Hash-map таблице уже есть такой путь? лови ошибку
             return Err(ServerError::HandlerError(format!(
@@ -95,23 +95,23 @@ impl Server {
     }
 
     #[allow(non_snake_case)]
-    pub fn GET(&mut self, path: String, handler: HandlerFn) -> Result<(), ServerError> {
-        self.add_handler(Method::GET, path, handler)
+    pub fn GET(&mut self, path: &'static str, handler: HandlerFn) {
+        self.add_handler(Method::GET, path, handler).unwrap()
     }
 
     #[allow(non_snake_case)]
-    pub fn POST(&mut self, path: String, handler: HandlerFn) -> Result<(), ServerError> {
-        self.add_handler(Method::POST, path, handler)
+    pub fn POST(&mut self, path: &'static str, handler: HandlerFn) {
+        self.add_handler(Method::POST, path, handler).unwrap()
     }
 
     #[allow(non_snake_case)]
-    pub fn PUT(&mut self, path: String, handler: HandlerFn) -> Result<(), ServerError> {
-        self.add_handler(Method::PUT, path, handler)
+    pub fn PUT(&mut self, path: &'static str, handler: HandlerFn) {
+        self.add_handler(Method::PUT, path, handler).unwrap()
     }
 
     #[allow(non_snake_case)]
-    pub fn DELETE(&mut self, path: String, handler: HandlerFn) -> Result<(), ServerError> {
-        self.add_handler(Method::DELETE, path, handler)
+    pub fn DELETE(&mut self, path: &'static str, handler: HandlerFn) {
+        self.add_handler(Method::DELETE, path, handler).unwrap()
     }
 
     /*

--- a/src/lib/parse_funcs.rs
+++ b/src/lib/parse_funcs.rs
@@ -107,15 +107,7 @@ pub fn deser_response(response: Response) -> String {
 
     // ------------ ЧАСТЬ №2 ------------ Формируем Headers для http-raw-ответа
     // if let ПАТТЕРН = ВЫРАЖЕНИЕ { … } else { … }
-    let headers_from_struct: Option<Vec<String>> = if let Some(headers) =
-        // получу в итоге Some(headers) или None
-        response.headers
-    {
-        // распакова response.headers: Option<Vec<String>>
-        Some(headers) // если там что-то есть, то верну Some(headers), т.е. упаковываю обратно в Some
-    } else {
-        None // если ничего нет, то None
-    };
+    let headers_from_struct: Option<Vec<String>> = response.headers;
 
     if let Some(headers_vector) = headers_from_struct {
         // if let Some(...) пытается распаковать headers_from_struct
@@ -150,7 +142,7 @@ pub fn deser_response(response: Response) -> String {
         String::new()
     };
 
-    if !(body_from_struct.len() == 0) {
+    if !(body_from_struct.is_empty()) {
         http_raw_response.push_str(&format!("Content-Length: {}\r\n", body_from_struct.len()));
         // макрос format! возвращает String -- в него можно добавить значение переменной
     }

--- a/src/lib/req_res_structs.rs
+++ b/src/lib/req_res_structs.rs
@@ -38,6 +38,6 @@ impl std::fmt::Display for Method {
             Method::OTHER => "OTHER",
         };
         // макрос write! записывает в форматер f строку s
-        write!(f, "{}", stroka)
+        write!(f, "{stroka}")
     }
 }

--- a/src/lib/request.rs
+++ b/src/lib/request.rs
@@ -40,14 +40,20 @@ impl Request {
     }
 
     // ПРОВИРЯЕТ ЧТО ПУТЬ ИЗ РЕКВЕСТА И ПУТЬ ИЗ АРГУМЕНТА АНАЛОГИЧНЫ
-    // НЕ СЧИТАЯ ВСЯКИХ ТАМ БЛЯТЬ АРГУМЕНТОВ
-    pub fn is_exact(&mut self, path: &str) -> bool {
-        let request_chunks: Vec<&str> = self.path.split("/").collect();
-        for (i, key_chunk) in path.split("/").enumerate() {
-            if i == 0 {
-                continue;
-            }
-            if !key_chunk.starts_with(":") && (key_chunk != request_chunks[i]) {
+    // НЕ СЧИТАЯ ВСЯКИХ ТАМ АРГУМЕНТОВ
+    pub fn is_similar(&mut self, path: &str) -> bool {
+        let request_chunks: Vec<&str> = self.path.split("/").filter(|el| !el.is_empty()).collect();
+        let key_chunks: Vec<&str> = path.split("/").filter(|el| !el.is_empty()).collect();
+
+        if request_chunks.len() != key_chunks.len() {
+            return false;
+        };
+
+        println!("Key chunks: {key_chunks:?}");
+        println!("Request chunks: {request_chunks:?}");
+
+        for (i, key_chunk) in key_chunks.iter().enumerate() {
+            if !key_chunk.starts_with(":") && (*key_chunk != request_chunks[i]) {
                 return false;
             }
         }
@@ -78,7 +84,7 @@ mod tests {
             .insert("id".to_string(), "label".to_string());
 
         request.parse_args(path);
-        assert!(request.is_exact(path));
+        assert!(request.is_similar(path));
         assert_eq!(request, expected_request);
     }
 }

--- a/src/lib/request.rs
+++ b/src/lib/request.rs
@@ -49,9 +49,6 @@ impl Request {
             return false;
         };
 
-        println!("Key chunks: {key_chunks:?}");
-        println!("Request chunks: {request_chunks:?}");
-
         for (i, key_chunk) in key_chunks.iter().enumerate() {
             if !key_chunk.starts_with(":") && (*key_chunk != request_chunks[i]) {
                 return false;

--- a/src/lib/request.rs
+++ b/src/lib/request.rs
@@ -47,7 +47,7 @@ impl Request {
             if i == 0 {
                 continue;
             }
-            if !key_chunk.starts_with(":") && !(key_chunk == request_chunks[i]) {
+            if !key_chunk.starts_with(":") && (key_chunk != request_chunks[i]) {
                 return false;
             }
         }


### PR DESCRIPTION
# Изменил
- В хэшмапах с хэндлерами теперь не  String, а &'static str. Тоесть ссылки на строки, которые существуют на протяжении всего времени выполнения программы
- Чуть-чуть изменил логику проверки совпадения пути
- Добавил примеры хэндлеров с методом POST (они работают)
- Теперь есть стандартные ответы. Если не подходит ни один путь - 404, если неправильный запрос - 403